### PR TITLE
Connect directly to TagetID without querying the Tabs json

### DIFF
--- a/PyChromeDevTools/__init__.py
+++ b/PyChromeDevTools/__init__.py
@@ -54,6 +54,17 @@ class ChromeInterface(object):
         self.ws = websocket.create_connection(wsurl)
         self.ws.settimeout(self.timeout)
 
+    def conntect_targetID(self, targetID):
+        try:
+            wsurl = '"ws://{}:{}/devtools/page/{}'.format(self.host, self.port, targetID)
+            self.close()
+            self.ws = websocket.create_connection(wsurl)
+            self.ws.settimeout(self.timeout)
+        except:
+            wsurl = self.tabs[0]['webSocketDebuggerUrl']
+            self.ws = websocket.create_connection(wsurl)
+            self.ws.settimeout(self.timeout)    
+        
     def close(self):
         if self.ws:
             self.ws.close()

--- a/PyChromeDevTools/__init__.py
+++ b/PyChromeDevTools/__init__.py
@@ -56,7 +56,7 @@ class ChromeInterface(object):
 
     def conntect_targetID(self, targetID):
         try:
-            wsurl = '"ws://{}:{}/devtools/page/{}'.format(self.host, self.port, targetID)
+            wsurl = 'ws://{}:{}/devtools/page/{}'.format(self.host, self.port, targetID)
             self.close()
             self.ws = websocket.create_connection(wsurl)
             self.ws.settimeout(self.timeout)


### PR DESCRIPTION
After creating a new Target you will get directly the targetID of that new target. To avoid querying the json, finding the tab id and then connect i've added a function to connect directly to the new targetID