### PR TITLE
Fix early timeout for wait_event and wait_result

### DIFF
--- a/PyChromeDevTools/__init__.py
+++ b/PyChromeDevTools/__init__.py
@@ -98,6 +98,8 @@ class ChromeInterface(object):
                 if 'method' in parsed_message and parsed_message['method'] == event:
                     matching_message = parsed_message
                     break
+            except websocket.WebSocketTimeoutException:
+                continue
             except:
                 break
         return (matching_message, messages)
@@ -119,6 +121,8 @@ class ChromeInterface(object):
                 if 'result' in parsed_message and parsed_message['id'] == result_id:
                     matching_result = parsed_message
                     break
+            except websocket.WebSocketTimeoutException:
+                continue
             except:
                 break
         return (matching_result, messages)


### PR DESCRIPTION
I added a check that won't break on a `WebSocketTimeoutException`. Without this check, the code was just timing out after a few ms, even with large timeout values. 